### PR TITLE
Allow getting the server's name from the IrcClient

### DIFF
--- a/src/IrcClient.php
+++ b/src/IrcClient.php
@@ -223,4 +223,9 @@ class IrcClient
 
         return $channel;
     }
+
+    public function getConnection(): IrcConnection
+    {
+        return $this->connection;
+    }
 }

--- a/src/IrcConnection.php
+++ b/src/IrcConnection.php
@@ -138,4 +138,9 @@ class IrcConnection
     {
         $this->eventHandlerCollection->invoke(new Event('data', [$message]));
     }
+
+    public function getServer(): string
+    {
+        return $this->server;
+    }
 }

--- a/tests/IrcClientTest.php
+++ b/tests/IrcClientTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Jerodev\PhpIrcClient\IrcClient;
+use Jerodev\PhpIrcClient\Options\ClientOptions;
+
+final class IrcClientTest extends TestCase
+{
+    public function testGetConnection(): void
+    {
+        $options = new ClientOptions('PhpIrcBot', ['#php-irc-client-test']);
+        $client = new IrcClient('chat.example.com:6667', $options);
+
+        $connection = $client->getConnection();
+        self::assertSame('chat.example.com:6667', $connection->getServer());
+    }
+}


### PR DESCRIPTION
For a service that might have multiple IRC connections, I need to be able to get the server's name from an IRC client.