### PR TITLE
Add "all" target to Composer scripts for running all checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,11 @@
     "minimum-stability": "stable",
     "autoload": {
         "psr-4": {
-            "Jerodev\\PhpIrcClient\\": "src/",
+            "Jerodev\\PhpIrcClient\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Tests\\": "tests/"
         }
     },
@@ -20,6 +24,10 @@
         "sort-packages": true
     },
     "scripts": {
+        "all": [
+            "@phpstan",
+            "@coverage"
+        ],
         "coverage": "phpunit --coverage-html=vendor/coverage",
         "phpstan": "phpstan analyse src tests --level=5",
         "test": "phpunit"

--- a/composer.lock
+++ b/composer.lock
@@ -908,16 +908,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.13",
+            "version": "1.10.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "f07bf8c6980b81bf9e49d44bd0caf2e737614a70"
+                "reference": "d232901b09e67538e5c86a724be841bea5768a7c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f07bf8c6980b81bf9e49d44bd0caf2e737614a70",
-                "reference": "f07bf8c6980b81bf9e49d44bd0caf2e737614a70",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d232901b09e67538e5c86a724be841bea5768a7c",
+                "reference": "d232901b09e67538e5c86a724be841bea5768a7c",
                 "shasum": ""
             },
             "require": {
@@ -966,7 +966,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-12T19:29:52+00:00"
+            "time": "2023-04-19T13:47:27+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",


### PR DESCRIPTION
Also, split autoload-dev out.